### PR TITLE
disable user text selection while resizing images

### DIFF
--- a/src/actions/ResizeAction.js
+++ b/src/actions/ResizeAction.js
@@ -32,7 +32,6 @@ export default class ResizeAction extends Action {
     this.formatter.overlay.appendChild(this.bottomLeftHandle);
 
     this.repositionHandles(this.formatter.options.resize.handleStyle);
-    this.toggleUserSelect(false);
   }
 
   onDestroy() {
@@ -41,7 +40,6 @@ export default class ResizeAction extends Action {
     this.formatter.overlay.removeChild(this.topRightHandle);
     this.formatter.overlay.removeChild(this.bottomRightHandle);
     this.formatter.overlay.removeChild(this.bottomLeftHandle);
-    this.toggleUserSelect(true);
   }
 
   createHandle(position: string, cursor: string): HTMLElement {
@@ -126,6 +124,8 @@ export default class ResizeAction extends Action {
       return;
     }
 
+    this.toggleUserSelect(false);
+
     const deltaX = event.clientX - this.dragStartX;
     let newWidth = 0;
 
@@ -145,6 +145,7 @@ export default class ResizeAction extends Action {
 
   onMouseUp = () => {
     this.setCursor('');
+    this.toggleUserSelect(true);
     document.removeEventListener('mousemove', this.onDrag);
     document.removeEventListener('mouseup', this.onMouseUp);
   };

--- a/src/actions/ResizeAction.js
+++ b/src/actions/ResizeAction.js
@@ -32,6 +32,7 @@ export default class ResizeAction extends Action {
     this.formatter.overlay.appendChild(this.bottomLeftHandle);
 
     this.repositionHandles(this.formatter.options.resize.handleStyle);
+    this.toggleUserSelect(false);
   }
 
   onDestroy() {
@@ -40,6 +41,7 @@ export default class ResizeAction extends Action {
     this.formatter.overlay.removeChild(this.topRightHandle);
     this.formatter.overlay.removeChild(this.bottomRightHandle);
     this.formatter.overlay.removeChild(this.bottomLeftHandle);
+    this.toggleUserSelect(true);
   }
 
   createHandle(position: string, cursor: string): HTMLElement {
@@ -146,4 +148,27 @@ export default class ResizeAction extends Action {
     document.removeEventListener('mousemove', this.onDrag);
     document.removeEventListener('mouseup', this.onMouseUp);
   };
+
+  toggleUserSelect(enabled: boolean) {
+    if (enabled) {
+      document.body.style.setProperty("-moz-user-select", "auto");
+      document.body.style.setProperty("-webkit-user-select", "auto");
+      document.body.style.setProperty("-ms-user-select", "auto");
+      document.body.style.setProperty("-o-user-select", "auto");
+      document.body.style.setProperty("user-select", "auto");
+      document.onselectstart = () => true;
+      document.onselect = () => true;
+      document.onselectionchange = () => true;
+      return;
+    }
+
+    document.body.style.setProperty("-moz-user-select", "none");
+    document.body.style.setProperty("-webkit-user-select", "none");
+    document.body.style.setProperty("-ms-user-select", "none");
+    document.body.style.setProperty("-o-user-select", "none");
+    document.body.style.setProperty("user-select", "none");
+    document.onselectstart = () => false;
+    document.onselect = () => false;
+    document.onselectionchange = () => false;
+  }
 }


### PR DESCRIPTION
I noticed that while dragging the handles to resize images, you'd also be selecting any text you drag over. This PR fixes that issue by disabling user select while the resize handles are visible.